### PR TITLE
Use Release namespace

### DIFF
--- a/ir-engine/templates/api-server-cluster-role-binding.yaml
+++ b/ir-engine/templates/api-server-cluster-role-binding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ir-engine.api.serviceAccountName" . }}
-    namespace: default
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/ir-engine/templates/instance-server-cluster-role-binding.yaml
+++ b/ir-engine/templates/instance-server-cluster-role-binding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ir-engine.instanceserver.serviceAccountName" . }}
-    namespace: default
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/ir-engine/templates/instance-server-serviceaccount.yaml
+++ b/ir-engine/templates/instance-server-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "ir-engine.instanceserver.serviceAccountName" . }}
+  name: {{ include "ir-engine.instanceserver.serviceAccountName" . }}  
   labels:
     {{- include "ir-engine.instanceserver.labels" . | nindent 4 }}
     {{- with .Values.instanceserver.serviceAccount.annotations }}

--- a/ir-engine/templates/task-server-cluster-role-binding.yaml
+++ b/ir-engine/templates/task-server-cluster-role-binding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ir-engine.taskserver.serviceAccountName" . }}
-    namespace: default
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/ir-engine/templates/test-bot-cluster-role-binding.yaml
+++ b/ir-engine/templates/test-bot-cluster-role-binding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ir-engine.testbot.serviceAccountName" . }}
-    namespace: default
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
When spinning up the instanceserver pod in `gcp`, was running into permissions errors:

```
{"error":"gameservers.agones.dev \"dev-instanceserver-5w66n-59gl2\" is forbidden: User \"system:serviceaccount:ir-engine-dev:dev-instanceserver\" cannot list resource \"gameservers\" in API group \"agones.dev\" in the namespace \"ir-engine-dev\"","gsKey":"ir-engine-dev/dev-instanceserver-5w66n-59gl2","message":"Connection to Kubernetes service failed","severity":"info","source":"*sdkserver.SDKServer","time":"2025-02-04T17:11:13.650063924Z","try":0}
```

The issue here was that the cluster binding was associated with a service account in the `default` namespace, rather than in the actual release namespace 