### PR TITLE
Fix RBAC and include redis

### DIFF
--- a/configs/dev.gcp.redis-values.yaml
+++ b/configs/dev.gcp.redis-values.yaml
@@ -1,0 +1,20 @@
+master:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nodepool
+            operator: In
+            values:
+            - redis-dev-nodepool
+replica:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nodepool
+            operator: In
+            values:
+            - redis-dev-nodepool

--- a/configs/prd.gcp.redis-values.yaml
+++ b/configs/prd.gcp.redis-values.yaml
@@ -1,0 +1,20 @@
+master:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nodepool
+            operator: In
+            values:
+            - redis-prd-nodepool
+replica:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nodepool
+            operator: In
+            values:
+            - redis-prd-nodepool

--- a/configs/pre.gcp.redis-values.yaml
+++ b/configs/pre.gcp.redis-values.yaml
@@ -1,0 +1,20 @@
+master:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nodepool
+            operator: In
+            values:
+            - redis-pre-nodepool
+replica:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nodepool
+            operator: In
+            values:
+            - redis-pre-nodepool

--- a/ir-engine-builder/templates/builder-cluster-role.yaml
+++ b/ir-engine-builder/templates/builder-cluster-role.yaml
@@ -10,6 +10,7 @@ rules:
       - ""
     resources:
       - pods
+      - pods/log
       - endpoints
       - deployments
       - secrets
@@ -17,13 +18,15 @@ rules:
       - configmaps
       - clusterroles
       - services
+      - jobs
+      - events
     verbs:
       - get
       - list
       - watch
       - create
-      - patch
       - update
+      - patch
       - delete
   - apiGroups:
       - apps
@@ -34,8 +37,8 @@ rules:
       - list
       - watch
       - create
-      - patch
       - update
+      - patch
       - delete
   - apiGroups:
       - agones.dev
@@ -47,18 +50,27 @@ rules:
       - gameserver
       - gameservers.agones.dev
       - gameserversets
+      - configmap
     verbs:
       - get
       - list
       - watch
+      - create
+      - update
       - patch
+      - delete
   - apiGroups:
       - autoscaling.agones.dev
     resources:
       - fleetautoscalers
     verbs:
       - get
+      - list
+      - watch
+      - create
+      - update
       - patch
+      - delete
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -67,7 +79,11 @@ rules:
     verbs:
       - get
       - list
-      - patch 
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - batch
     resources:
@@ -75,13 +91,22 @@ rules:
       - jobs
     verbs:
       - get
-      - patch
       - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses
     verbs:
       - get
+      - list
+      - watch
+      - create
+      - update
       - patch
+      - delete
 {{- end }}


### PR DESCRIPTION
The `deploy.sh` script within the builder was failing due to a lack of RBAC perms. I've added all the necessary permissions. If I now run `helm upgrade` command in `deploy.sh` from within the builder, the deploy is successful. 

```
root@dev-builder-ir-engine-builder-4l6l2:/app# helm upgrade --install --namespace ir-engine-dev --reuse-values --set cloudProvider=gcp,googleProjectID=ir-engine-dev,taskserver.image.repository=us-central1-docker.pkg.dev/ir-engine-dev/ir-engine-dev-taskserver/ir-engine-dev-taskserver,taskserver.image.tag=1.6.0_712b023b93aa0f69c0ac99ac2649490153c6a726__27-02-25T20-46-24,api.image.repository=us-central1-docker.pkg.dev/ir-engine-dev/ir-engine-dev-api/ir-engine-dev-api,api.image.tag=1.6.0_712b023b93aa0f69c0ac99ac2649490153c6a726__27-02-25T20-46-24,instanceserver.image.repository=us-central1-docker.pkg.dev/ir-engine-dev/ir-engine-dev-instanceserver/ir-engine-dev-instanceserver,instanceserver.image.tag=1.6.0_712b023b93aa0f69c0ac99ac2649490153c6a726__27-02-25T20-46-24,testbot.image.repository=us-central1-docker.pkg.dev/ir-engine-dev/ir-engine-dev-testbot/ir-engine-dev-testbot,testbot.image.tag=1.6.0_712b023b93aa0f69c0ac99ac2649490153c6a726__27-02-25T20-46-24,batchinvalidator.image.repository=us-central1-docker.pkg.dev/ir-engine-dev/ir-engine-dev-api/ir-engine-dev-api,batchinvalidator.image.tag=1.6.0_712b023b93aa0f69c0ac99ac2649490153c6a726__27-02-25T20-46-24 dev ir-engine/ir-engine
Release "dev" has been upgraded. Happy Helming!
NAME: dev
LAST DEPLOYED: Thu Feb 27 20:58:49 2025
NAMESPACE: ir-engine-dev
STATUS: deployed
REVISION: 3
NOTES:
Thank you for installing Infinite Reality Engine

```