### PR TITLE
feat: add PostgreSQL Cloud SQL proxy support to Helm charts

### DIFF
--- a/ir-engine-builder/templates/builder-job.yaml
+++ b/ir-engine-builder/templates/builder-job.yaml
@@ -159,7 +159,7 @@ spec:
         {{ end }}
       {{- if eq .Values.cloudProvider "gcp" }}
       initContainers:
-        - name: cloud-sql-proxy
+        - name: cloud-sql-proxy-mysql
           restartPolicy: Always
           # It is recommended to use the latest version of the Cloud SQL Auth Proxy
           # Make sure to update on a regular schedule!
@@ -174,7 +174,7 @@ spec:
             - "--auto-iam-authn"
 
             # Replace DB_PORT with the port the proxy should listen on
-            - "--port=3306"            
+            - "--port=3306"
             - "{{ .Values.googleProjectID }}:us-central1:{{ .Release.Namespace }}-mysql"
 
           securityContext:
@@ -185,7 +185,35 @@ spec:
             requests:
               memory: "2Gi"
               cpu: "1"
-      {{- end }}  
+        {{- if .Values.vectordb.enabled }}
+        - name: cloud-sql-proxy-postgres
+          restartPolicy: Always
+          # It is recommended to use the latest version of the Cloud SQL Auth Proxy
+          # Make sure to update on a regular schedule!
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+          args:
+            # If connecting from a VPC-native GKE cluster, you can use the
+            # following flag to have the proxy connect over private IP
+            - "--private-ip"
+
+            # Enable structured logging with LogEntry format:
+            - "--structured-logs"
+            - "--auto-iam-authn"
+
+            # Replace DB_PORT with the port the proxy should listen on
+            - "--port=5432"
+            - "{{ .Values.googleProjectID }}:us-central1:{{ .Release.Namespace }}-postgres"
+
+          securityContext:
+            # The default Cloud SQL Auth Proxy image runs as the
+            # "nonroot" user and group (uid: 65532) by default.
+            runAsNonRoot: true
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+        {{- end}}
+      {{- end }}
 
       volumes:
       - name: dind-storage

--- a/ir-engine-kaniko/templates/kaniko-client-pod.yaml
+++ b/ir-engine-kaniko/templates/kaniko-client-pod.yaml
@@ -129,7 +129,7 @@ spec:
 
       {{- if eq .Values.cloudProvider "gcp" }}
       initContainers:
-        - name: cloud-sql-proxy
+        - name: cloud-sql-proxy-mysql
           restartPolicy: Always
           # It is recommended to use the latest version of the Cloud SQL Auth Proxy
           # Make sure to update on a regular schedule!
@@ -155,6 +155,34 @@ spec:
             requests:
               memory: "2Gi"
               cpu: "1"
+        {{- if .Values.vectordb.enabled }}
+        - name: cloud-sql-proxy-postgres
+          restartPolicy: Always
+          # It is recommended to use the latest version of the Cloud SQL Auth Proxy
+          # Make sure to update on a regular schedule!
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+          args:
+            # If connecting from a VPC-native GKE cluster, you can use the
+            # following flag to have the proxy connect over private IP
+            - "--private-ip"
+
+            # Enable structured logging with LogEntry format:
+            - "--structured-logs"
+            - "--auto-iam-authn"
+
+            # Replace DB_PORT with the port the proxy should listen on
+            - "--port=5432"
+            - "{{ .Values.googleProjectID }}:us-central1:{{ .Release.Namespace }}-postgres"
+
+          securityContext:
+            # The default Cloud SQL Auth Proxy image runs as the
+            # "nonroot" user and group (uid: 65532) by default.
+            runAsNonRoot: true
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+        {{- end}}
       {{- end }}
       volumes:
         - name: client-kaniko-storage

--- a/ir-engine/templates/api-server-deployment.yaml
+++ b/ir-engine/templates/api-server-deployment.yaml
@@ -169,9 +169,9 @@ spec:
                 secretKeyRef:
                   name: {{ $releaseName }}-redis
                   key: redis-password      
-        {{- if eq .Values.cloudProvider "gcp" }}            
-        - name: cloud-sql-proxy
-          restartPolicy: Always # Indicates a special type of sidecar, which will last for the entire lifecycle of the pod 
+        {{- if eq .Values.cloudProvider "gcp" }}
+        - name: cloud-sql-proxy-mysql
+          restartPolicy: Always # Indicates a special type of sidecar, which will last for the entire lifecycle of the pod
           image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
           args:
             - "--private-ip"
@@ -181,6 +181,19 @@ spec:
             - "{{ .Values.googleProjectID }}:us-central1:{{ .Release.Namespace }}-mysql"
           securityContext:
             runAsNonRoot: true
+        {{- if .Values.vectordb.enabled }}
+        - name: cloud-sql-proxy-postgres
+          restartPolicy: Always # Indicates a special type of sidecar, which will last for the entire lifecycle of the pod
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+          args:
+            - "--private-ip"
+            - "--structured-logs"
+            - "--port=5432"
+            - "--auto-iam-authn"
+            - "{{ .Values.googleProjectID }}:us-central1:{{ .Release.Namespace }}-postgres"
+          securityContext:
+            runAsNonRoot: true
+        {{- end}}
         {{- end}}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:

--- a/ir-engine/templates/batch-invalidator-cronjob.yaml
+++ b/ir-engine/templates/batch-invalidator-cronjob.yaml
@@ -16,8 +16,8 @@ spec:
           serviceAccountName: {{ include "ir-engine.batchinvalidator.serviceAccountName" . }}
           {{- if eq .Values.cloudProvider "gcp" }}
           initContainers:
-            - name: cloud-sql-proxy
-              restartPolicy: Always # Indicates a special type of sidecar, which will last for the entire lifecycle of the pod 
+            - name: cloud-sql-proxy-mysql
+              restartPolicy: Always # Indicates a special type of sidecar, which will last for the entire lifecycle of the pod
               image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
               args:
                 - "--private-ip"
@@ -27,6 +27,19 @@ spec:
                 - "{{ .Values.googleProjectID }}:us-central1:{{ .Release.Namespace }}-mysql"
               securityContext:
                 runAsNonRoot: true
+            {{- if .Values.vectordb.enabled }}
+            - name: cloud-sql-proxy-postgres
+              restartPolicy: Always # Indicates a special type of sidecar, which will last for the entire lifecycle of the pod
+              image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+              args:
+                - "--private-ip"
+                - "--structured-logs"
+                - "--port=5432"
+                - "--auto-iam-authn"
+                - "{{ .Values.googleProjectID }}:us-central1:{{ .Release.Namespace }}-postgres"
+              securityContext:
+                runAsNonRoot: true
+            {{- end}}
           {{- end}}
           containers:              
             - name: batch-invalidator

--- a/ir-engine/templates/instance-server-fleet.yaml
+++ b/ir-engine/templates/instance-server-fleet.yaml
@@ -96,7 +96,7 @@ spec:
           {{ end }}
           containers:
           {{- if eq .Values.cloudProvider "gcp" }}
-            - name: cloud-sql-proxy
+            - name: cloud-sql-proxy-mysql
               image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
               args:
                 - "--private-ip"
@@ -106,7 +106,19 @@ spec:
                 - "{{ .Values.googleProjectID }}:us-central1:{{ .Release.Namespace }}-mysql"
               securityContext:
                 runAsNonRoot: true
-          {{- end}}               
+            {{- if .Values.vectordb.enabled }}
+            - name: cloud-sql-proxy-postgres
+              image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+              args:
+                - "--private-ip"
+                - "--structured-logs"
+                - "--port=5432"
+                - "--auto-iam-authn"
+                - "{{ .Values.googleProjectID }}:us-central1:{{ .Release.Namespace }}-postgres"
+              securityContext:
+                runAsNonRoot: true
+            {{- end}}
+          {{- end}}
             - name: {{ include "ir-engine.instanceserver.fullname" . }}
               image: "{{ .Values.instanceserver.image.repository }}:{{ .Values.instanceserver.image.tag }}"
               imagePullPolicy: {{ .Values.instanceserver.image.pullPolicy }}


### PR DESCRIPTION
- add postgres proxy containers alongside existing MySQL proxies
- configure port 5432 for PostgreSQL connections
- enable conditional deployment based on vectordb.enabled flag
- maintain same IAM authentication and private IP configuration
- update all deployment templates: api-server, instance-server, batch-invalidator, builder, kaniko