### PR TITLE
chore: bump chart versions for PostgreSQL proxy support

### DIFF
--- a/ir-engine-builder/Chart.yaml
+++ b/ir-engine-builder/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.4
+version: 1.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/ir-engine-kaniko/Chart.yaml
+++ b/ir-engine-kaniko/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/ir-engine/templates/api-server-deployment.yaml
+++ b/ir-engine/templates/api-server-deployment.yaml
@@ -46,6 +46,40 @@ spec:
             {{- if (.Values.vectordb).enabled }}
             - name: VECTORDB_ENABLED
               value: "true"
+            {{- if .Values.vectordb }}
+            - name: POSTGRES_USER
+              value: {{ .Values.vectordb.user }}
+            - name: POSTGRES_DATABASE
+              value: {{ .Values.vectordb.database }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.vectordb.password | quote }}
+            - name: POSTGRES_HOST
+              value: {{ .Values.vectordb.host | quote }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.vectordb.port | quote }}
+            {{- else if eq .Values.cloudProvider "gcp" }}
+            - name: POSTGRES_USER
+              value: "ir-engine-sa@{{ .Values.googleProjectID }}.iam"
+            - name: POSTGRES_DATABASE
+              value: "{{ .Release.Namespace }}-vector-db"
+            - name: POSTGRES_PASSWORD
+              value: ""
+            - name: POSTGRES_HOST
+              value: "127.0.0.1"
+            - name: POSTGRES_PORT
+              value: "5432"
+            {{- else }}
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_DATABASE
+              value: vector-db
+            - name: POSTGRES_PASSWORD
+              value: postgres
+            - name: POSTGRES_HOST
+              value: host.minikube.internal
+            - name: POSTGRES_PORT
+              value: 5432
+            {{- end }}
             {{- end }}
             {{ if .Values.client.serveFromApi }}
             - name: SERVE_CLIENT_FROM_API

--- a/ir-engine/templates/api-server-deployment.yaml
+++ b/ir-engine/templates/api-server-deployment.yaml
@@ -43,10 +43,9 @@ spec:
               value: "api"
             - name: KUBERNETES
               value: "true"
-            {{- if (.Values.vectordb).enabled }}
+            {{- if and .Values.vectordb (.Values.vectordb).enabled }}
             - name: VECTORDB_ENABLED
               value: "true"
-            {{- if .Values.vectordb }}
             - name: POSTGRES_USER
               value: {{ .Values.vectordb.user }}
             - name: POSTGRES_DATABASE
@@ -57,7 +56,9 @@ spec:
               value: {{ .Values.vectordb.host | quote }}
             - name: POSTGRES_PORT
               value: {{ .Values.vectordb.port | quote }}
-            {{- else if eq .Values.cloudProvider "gcp" }}
+            {{- else if and (eq .Values.cloudProvider "gcp") (.Values.vectordb) (.Values.vectordb).enabled }}
+            - name: VECTORDB_ENABLED
+              value: "true"
             - name: POSTGRES_USER
               value: "ir-engine-sa@{{ .Values.googleProjectID }}.iam"
             - name: POSTGRES_DATABASE
@@ -68,18 +69,6 @@ spec:
               value: "127.0.0.1"
             - name: POSTGRES_PORT
               value: "5432"
-            {{- else }}
-            - name: POSTGRES_USER
-              value: postgres
-            - name: POSTGRES_DATABASE
-              value: vector-db
-            - name: POSTGRES_PASSWORD
-              value: postgres
-            - name: POSTGRES_HOST
-              value: host.minikube.internal
-            - name: POSTGRES_PORT
-              value: 5432
-            {{- end }}
             {{- end }}
             {{ if .Values.client.serveFromApi }}
             - name: SERVE_CLIENT_FROM_API

--- a/ir-engine/values.yaml
+++ b/ir-engine/values.yaml
@@ -359,3 +359,6 @@ batchinvalidator:
     create: true
     annotations: {}
     name:
+
+vectordb:
+  enabled: false


### PR DESCRIPTION
- bump ir-engine-builder to v1.1.5 (added VECTORDB_ENABLED env var)
- bump ir-engine-kaniko to v1.0.5 (removed unnecessary VITE_VECTORDB_ENABLED)
- prepare for independent chart publishing